### PR TITLE
[feat] Sidebar에 프로필 수정 페이지로 넘어가는 링크 컴포넌트 추가 (SidebarProfile.tsx)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-slot": "^1.1.2",
         "@tanstack/react-query": "^5.66.7",
         "axios": "^1.7.9",
+        "boring-avatars": "^1.11.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.5.0",
@@ -1566,6 +1567,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/boring-avatars": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/boring-avatars/-/boring-avatars-1.11.2.tgz",
+      "integrity": "sha512-3+wkwPeObwS4R37FGXMYViqc4iTrIRj5yzfX9Qy4mnpZ26sX41dGMhsAgmKks1r/uufY1pl4vpgzMWHYfJRb2A==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-slot": "^1.1.2",
     "@tanstack/react-query": "^5.66.7",
     "axios": "^1.7.9",
+    "boring-avatars": "^1.11.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.5.0",

--- a/src/components/Common/NavigationBar.tsx
+++ b/src/components/Common/NavigationBar.tsx
@@ -35,7 +35,7 @@ export default function NavigationBar({
         isCollapsed={isCollapsed}
       />
       <div
-        className={cn(isCollapsed ? 'pl-[80px]' : 'pl-[200px]', 'pt-[80px]')}
+        className={cn(isCollapsed ? 'pl-[90px]' : 'pl-[200px]', 'pt-[80px]')}
       >
         {children}
       </div>

--- a/src/components/Common/Sidebar.tsx
+++ b/src/components/Common/Sidebar.tsx
@@ -6,6 +6,9 @@ import { HTMLAttributes } from 'react';
 import { cn } from 'src/lib/utils';
 import clsx from 'clsx';
 import { SidebarItem } from 'src/constants/sidebarItems';
+import dynamic from 'next/dynamic';
+
+const SidebarProfile = dynamic(() => import('./SidebarProfile'));
 
 type SidebarProps = {
   currentUrl: string;
@@ -24,6 +27,9 @@ export default function Sidebar({
   return (
     <aside className='h-lvh w-fit bg-bg' {...rest}>
       <ul className={cn(isCollapsed ? 'w-[90px]' : 'w-[200px]')}>
+        {currentUrl.startsWith('/my') && (
+          <SidebarProfile isCollapsed={isCollapsed} />
+        )}
         {sidebarItems.map(({ iconName, label, url }, index) => (
           <li
             key={index}

--- a/src/components/Common/SidebarProfile.tsx
+++ b/src/components/Common/SidebarProfile.tsx
@@ -1,0 +1,36 @@
+import Avatar from 'boring-avatars';
+import { cn } from './../../lib/utils';
+import Link from 'next/link';
+import Icon from 'src/icons/Icon';
+
+type SidebarProfileProps = {
+  isCollapsed: boolean;
+};
+
+export default function SidebarProfile({ isCollapsed }: SidebarProfileProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-y-[12px]',
+        isCollapsed ? 'h-[60px]' : 'h-[180px]'
+      )}
+    >
+      <Link href={'/my/dashboard'} className='relative'>
+        <Avatar name={'user'} variant='beam' size={isCollapsed ? 30 : 100} />
+        <div
+          className={cn(
+            'absolute bottom-0 right-0 flex h-[30px] w-[30px] items-center justify-center rounded-20 bg-bg-dark',
+            isCollapsed && 'opacity-0 hover:opacity-50'
+          )}
+        >
+          <Icon
+            name='EDIT'
+            size={16}
+            className='fill-bg-dark stroke-white stroke-[2px]'
+          />
+        </div>
+      </Link>
+      {!isCollapsed && <p className='text-h3'>user</p>}
+    </div>
+  );
+}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -9,7 +9,7 @@ type HeaderProps = {
 };
 
 const Header = ({ onToggleSidebar }: HeaderProps) => {
-  const userName = '컬처피플';
+  const userName = 'user';
   const router = useRouter();
   function handleLogout() {
     router.push('/');
@@ -18,7 +18,7 @@ const Header = ({ onToggleSidebar }: HeaderProps) => {
   return (
     <header className='fixed left-0 top-0 flex h-20 w-full items-center justify-between'>
       <div className='flex-[3]'>
-        <div className='mx-[40px] flex w-[280px] gap-10'>
+        <div className='mx-[34px] flex w-[280px] gap-10'>
           <button onClick={onToggleSidebar}>
             <Icon
               name='HAMBURGER_MENU'


### PR DESCRIPTION
# [feat] Sidebar에 프로필 수정 페이지로 넘어가는 링크 컴포넌트 추가 (SidebarProfile.tsx)

<br/>

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] develop 브랜치에서 최신 데이터를 가져오기 위한 PR

<br/><br/>

## PR 상세

### 주요 변경 사항
- 프로필 수정 페이지로 넘어가는 링크 컴포넌트(`SidebarProfile`)를 개발 후 `Sidebar` 최상단에 추가했습니다.
  - dynamic import를 사용해 `currentUrl`이 `/my`로 시작되는 경우에만 import 하도록 설정했습니다.

- 사이드바 축소 전/후 프로필 이미지 사이즈가 달라집니다.
  - 사이드바 축소 시, 프로필 이미지에 hover하면 수정 아이콘이 나타납니다. (`opacity: 50%`)

- `Link`를 사용해 프로필 이미지 클릭 시 프로필 수정 페이지로 이동하도록 설정했습니다.
  - 프로필 수정 페이지의 경로 대신 임시 경로(`/my/dashboard`)를 연결했습니다.

- 기타
  - `Sidebar`과의 정렬을 위해 `Header`, `NavagationBar` 사이즈를 일부 수정했습니다.
  - 사용자 이름을 `user`로 통일했습니다.

<br/>

### 스크린샷
- 사이드바 축소 전
  ![image](https://github.com/user-attachments/assets/00363df3-505c-4e90-b352-422d2fd14407)

- 사이드바 축소 후
  
![image](https://github.com/user-attachments/assets/d86d621f-1d3d-4647-acfd-857313bd9e2a)


- 사이드바 축소 후 hover 시
  
![image](https://github.com/user-attachments/assets/c24f0ec1-33cc-4ad1-a830-efdce43f330c)


<br/>

### 테스트
- 로컬에서 정상 작동 확인했습니다. (경로에 따른 `SidebarProfile` 렌더링 여부, 사이드바 축소 전/후 사이즈 변경, 링크 연결)

<br/>

### 참고사항
- 현재 개발하고 계신 프로필 수정 페이지의 경로를 `SidebarProfile`의 `Link`에 업데이트 해주시면 됩니다!

<br/><br/>

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 의도한 대로 동작하는지 테스트를 했습니다.
- [ ] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.
