### PR TITLE
[feat] CUL-116: 공통 컴포넌트 수정 및 개발

### DIFF
--- a/app/(auth-layout)/layout.tsx
+++ b/app/(auth-layout)/layout.tsx
@@ -1,6 +1,6 @@
 import '../../styles/globals.css';
 import React from 'react';
-import LogoAnimation from 'src/components/Common/LogoAnimation';
+import LogoAnimation from 'src/components/common/LogoAnimation';
 
 export const metadata = {
   title: '로그인 - My Next.js App',

--- a/app/(auth-layout)/login/page.tsx
+++ b/app/(auth-layout)/login/page.tsx
@@ -1,4 +1,4 @@
-import { Button } from 'src/components/Common/Button';
+import { Button } from 'src/components/common/Button';
 
 export default function Home() {
   return (

--- a/src/components/Common/ActionBar.tsx
+++ b/src/components/Common/ActionBar.tsx
@@ -16,7 +16,7 @@ export default function ActionBar({
   return (
     <div
       className={cn(
-        'flex items-center justify-between border-t border-border px-[20px] px-[40px] py-[10px]',
+        'flex items-center justify-between border-t border-divider px-[20px] px-[40px] py-[10px]',
         className
       )}
       {...rest}

--- a/src/components/Common/ActionBar.tsx
+++ b/src/components/Common/ActionBar.tsx
@@ -1,0 +1,32 @@
+import { cn } from './../../lib/utils';
+import { HTMLAttributes } from 'react';
+import { Button, ButtonProps } from './Button';
+
+type ActionBarProps = {
+  leftContent?: React.ReactNode;
+  buttons: ButtonProps[];
+} & HTMLAttributes<HTMLDivElement>;
+
+export default function ActionBar({
+  leftContent,
+  buttons,
+  className,
+  ...rest
+}: ActionBarProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between border-t border-border px-[20px] px-[40px] py-[10px]',
+        className
+      )}
+      {...rest}
+    >
+      <div>{leftContent}</div>
+      <div className='flex items-center gap-x-[10px]'>
+        {buttons.map((button) => (
+          <Button {...button} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Common/Dropdown.tsx
+++ b/src/components/Common/Dropdown.tsx
@@ -51,7 +51,7 @@ type MenuItem = {
 
 type DropdownProps = {
   type: DropdownType;
-  buttonText?: string;
+  buttonText?: React.ReactNode;
   menuItems: MenuItem[];
   fontSize?: DropdownFontSizes;
   buttonWidth?: DropdownButtonWidths;
@@ -61,6 +61,8 @@ type DropdownProps = {
   menuAlign?: MenuAlign;
   hideButtonBorder?: boolean;
   hideIcon?: boolean;
+  hideButtonHover?: boolean;
+  hideButtonPadding?: boolean;
 } & HTMLAttributes<HTMLDivElement>;
 
 export default function Dropdown({
@@ -75,6 +77,8 @@ export default function Dropdown({
   menuAlign = 'right',
   hideButtonBorder = false,
   hideIcon = false,
+  hideButtonHover = false,
+  hideButtonPadding = false,
   ...rest
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -103,10 +107,12 @@ export default function Dropdown({
       <button
         onClick={() => setIsOpen((prev) => !prev)}
         className={cn(
-          'flex items-center justify-between rounded-10 bg-white px-2 py-1 hover:bg-gray-50',
+          'flex items-center justify-between rounded-10 bg-bg px-2 py-1',
           !hideButtonBorder && 'border',
           dropdownButtonWidths[buttonWidth],
-          dropdownButtonHeights[buttonHeight]
+          dropdownButtonHeights[buttonHeight],
+          !hideButtonHover && 'hover:bg-gray-50',
+          hideButtonPadding && 'p-0'
         )}
       >
         <div>

--- a/src/components/Common/ListToolbar.tsx
+++ b/src/components/Common/ListToolbar.tsx
@@ -24,7 +24,7 @@ export default function ListToolbar({
   return (
     <div
       className={cn(
-        'flex items-center justify-between border-b border-border px-[20px]',
+        'flex items-center justify-between border-b border-divider px-[20px]',
         listToolbarSize[size],
         className
       )}

--- a/src/components/Common/ListToolbar.tsx
+++ b/src/components/Common/ListToolbar.tsx
@@ -1,0 +1,37 @@
+import { cn } from './../../lib/utils';
+import { HTMLAttributes } from 'react';
+
+const listToolbarSize = {
+  lg: 'h-[60px]',
+  sm: 'h-[45px]',
+};
+
+type ListToolbarSize = keyof typeof listToolbarSize;
+
+type ListToolbarProps = {
+  size?: ListToolbarSize;
+  leftContent?: React.ReactNode;
+  rightContent?: React.ReactNode;
+} & HTMLAttributes<HTMLDivElement>;
+
+export default function ListToolbar({
+  size = 'lg',
+  leftContent,
+  rightContent,
+  className,
+  ...rest
+}: ListToolbarProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between border-b border-border px-[20px]',
+        listToolbarSize[size],
+        className
+      )}
+      {...rest}
+    >
+      {leftContent}
+      {rightContent}
+    </div>
+  );
+}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -33,7 +33,7 @@ const Header = ({ onToggleSidebar }: HeaderProps) => {
   }, []);
 
   return (
-    <header className='fixed left-0 top-0 flex h-20 w-full items-center justify-between'>
+    <header className='fixed left-0 top-0 flex h-20 w-full items-center justify-between bg-bg'>
       <div className='flex-[3]'>
         <div className='mx-[34px] flex w-[280px] gap-10'>
           <button onClick={onToggleSidebar}>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -2,18 +2,35 @@ import Link from 'next/link';
 import Icon from '../../icons/Icon';
 import SearchBar from './SearchBar';
 import Dropdown from './Dropdown';
+import Avatar from 'boring-avatars';
 import { useRouter } from 'next/navigation';
+import { useRef, useEffect, useState } from 'react';
 
 type HeaderProps = {
   onToggleSidebar: () => void;
 };
 
 const Header = ({ onToggleSidebar }: HeaderProps) => {
-  const userName = 'user';
+  const profileCode = 1234;
   const router = useRouter();
+  const [isNotificationPopupOpen, setIsNotificationPopupOpen] = useState(false);
+  const notificationRef = useRef<HTMLButtonElement>(null);
   function handleLogout() {
     router.push('/');
   }
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        notificationRef.current &&
+        !notificationRef.current.contains(e.target as Node)
+      ) {
+        setIsNotificationPopupOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
   return (
     <header className='fixed left-0 top-0 flex h-20 w-full items-center justify-between'>
@@ -42,17 +59,23 @@ const Header = ({ onToggleSidebar }: HeaderProps) => {
         <div className='flex-[1]'></div>
       </div>
 
-      <div className='mr-7 flex flex-[1] justify-end gap-4'>
-        <button>
+      <div className='mr-7 flex flex-[1] items-center justify-end gap-3'>
+        <button
+          className='group flex h-[36px] w-[36px] items-center justify-center rounded-40 hover:bg-primary-main100'
+          onClick={() => setIsNotificationPopupOpen((prev) => !prev)}
+          ref={notificationRef}
+        >
           <Icon
             name='NOTIFICATION'
             size={23}
-            className='stroke-text-sub stroke-[2px]'
+            className='stroke-text-sub stroke-[2px] group-hover:stroke-primary'
           />
         </button>
         <Dropdown
           type='link'
-          buttonText={userName + ' 님'}
+          buttonText={
+            <Avatar name={String(profileCode)} variant='beam' size={36} />
+          }
           menuItems={[
             {
               label: '마이페이지',
@@ -63,6 +86,8 @@ const Header = ({ onToggleSidebar }: HeaderProps) => {
           buttonWidth='fit'
           hideButtonBorder
           hideIcon
+          hideButtonHover
+          hideButtonPadding
         />
       </div>
     </header>


### PR DESCRIPTION
# [feat] CUL-116: 공통 컴포넌트 수정 및 개발

<br/>

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] develop 브랜치에서 최신 데이터를 가져오기 위한 PR

<br/><br/>

## PR 상세

### 주요 변경 사항
- `Header`의 알림 버튼 디자인을 수정하고, 닉네임을 사용자 프로필 사진으로 대체했습니다.
  - 알림 버튼 hover 시 배경 색상, 아이콘 색상 변경
  - 알림 팝업 여부(`isNotificationPopupOpen`)를 상태 변수로 관리함
    - 알림 버튼 클릭 시 `true`, `true` 상태에서 외부 클릭 시 `false`
  - `Dropdown`의 버튼을 프로필 사진으로 변경하기 위해 `Dropdown`의 `props`를 일부 수정
    - 버튼에 프로필 사진을 넣기 위해 `buttonText` 타입을 `React.ReactNode`로 변경
    - 버튼 크기를 프로필 사진 영역에 맞추기 위해 `hideButtonHover`,  `hideButtonPadding` 옵션 추가
  - 배경 색상 `bg-bg` 추가

- 리스트 페이지의 정렬 등의 기능을 넣을 수 있는 `ListToolbar`을 개발했습니다.
  - `LeftSection`, `RightSection`에 컴포넌트를 추가
  - `size` 지정 가능 (`sm`, `lg`)

- 하단에 고정되는 버튼을 포함한 바 `ActionBar`을 개발했습니다.
  - `LeftSection`에 컴포넌트를 추가
  - `Buttons`에 버튼 속성을 리스트로 추가
    - 버튼 속성: `Button` 컴포넌트의 props 속성

- 폴더명 변경에 따라 import 경로를 업데이트 했습니다.
  - 기존: `Common/Button`
  - 변경: `common/Button`  

<br/>

### 스크린샷
- `Header` 기본 상태
  ![image](https://github.com/user-attachments/assets/61a4cb8a-d83d-4d10-933f-4b4ce76b8447)
- `Header` 알림 버튼 hover 시
  ![image](https://github.com/user-attachments/assets/86116a9c-2dcb-4b73-9026-b42edc3f87d5)
- `Header` 프로필 버튼 클릭 시
  ![image](https://github.com/user-attachments/assets/c8f070ac-667f-471e-9eab-110107dd7f25)
- `ListToolbar`
 ![image](https://github.com/user-attachments/assets/4e49d4b2-2f6a-4de3-a7fe-ed4cf912e53b)
- `ActionBar` 예시: 이벤트 디테일 페이지에 적용 
  ![image](https://github.com/user-attachments/assets/4d73f1ad-fa32-4bc9-a746-2286249c720c)

<br/>

### 테스트
- 로컬에서 정상 동작 및 스타일 적용 여부 확인했습니다.

<br/><br/>

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 의도한 대로 동작하는지 테스트를 했습니다.
- [ ] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.
