### PR TITLE
[feat] CUL-177: SearchBar 컴포넌트 스타일 variants 추가

### DIFF
--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -21,7 +21,7 @@ const searchBarVariants = cva(
   }
 );
 
-export interface SearchInputProps
+interface SearchInputProps
   extends InputHTMLAttributes<HTMLInputElement>,
     VariantProps<typeof searchBarVariants> {}
 

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -1,26 +1,73 @@
+'use client';
+import { useState } from 'react';
 import { InputHTMLAttributes } from 'react';
 import { cn } from '@/lib/utils';
+import { cva, type VariantProps } from 'class-variance-authority';
 import Icon from '@/icons/Icon';
 
-interface SearchInputProps extends InputHTMLAttributes<HTMLInputElement> {}
+const searchBarVariants = cva(
+  'flex h-9 w-full px-4 py-1 text-sm transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+  {
+    variants: {
+      variant: {
+        header: 'bg-bg-light rounded-3xl',
+        community: 'bg-white rounded-5 border border-border',
+        detail: 'bg-primary-main100 rounded-3xl pl-14 pr-12',
+      },
+    },
+    defaultVariants: {
+      variant: 'header',
+    },
+  }
+);
 
-const SearchBar = ({ ...props }: SearchInputProps) => {
+export interface SearchInputProps
+  extends InputHTMLAttributes<HTMLInputElement>,
+    VariantProps<typeof searchBarVariants> {}
+
+const SearchBar = ({ variant, className, ...props }: SearchInputProps) => {
+  const [inputValue, setInputValue] = useState('');
+
+  const isDetail = variant === 'detail';
+
   return (
-    <div className={cn('relative w-full rounded-lg', props.className)}>
-      <input
-        type='text'
+    <div className='relative w-full'>
+      <button
+        type='button'
         className={cn(
-          'flex h-9 w-full rounded-3xl bg-bg-light px-4 py-1 pr-16 text-sm transition-colors placeholder:text-text-disabled focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
+          'absolute top-1/2 flex -translate-y-1/2 cursor-pointer text-xs',
+          isDetail ? 'left-3' : 'right-3'
         )}
-      />
-
-      <div className='absolute text-xs transform -translate-y-1/2 cursor-pointer right-3 top-1/2'>
+      >
         <Icon
           name='SEARCH'
           size={18}
-          className='stroke-text-sub stroke-[2px]'
+          className={cn(
+            'stroke-[2px]',
+            isDetail ? 'stroke-primary' : 'stroke-text-sub'
+          )}
         />
-      </div>
+        {isDetail && (
+          <div className='h-4.5 ml-2.5 border-l border-primary-main500' />
+        )}
+      </button>
+
+      <input
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        className={cn(searchBarVariants({ variant }), className)}
+        {...props}
+      />
+
+      {isDetail && inputValue && (
+        <button
+          type='button'
+          className='absolute -translate-y-1/2 right-3 top-1/2 text-primary'
+          onClick={() => setInputValue('')}
+        >
+          <Icon name='CLOSE' size={13} />
+        </button>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# [feat] CUL-177: SearchBar 컴포넌트 스타일 variants 추가

<br/>

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] develop 브랜치에서 최신 데이터를 가져오기 위한 PR

<br/><br/>

## PR 상세

### 주요 변경 사항
- `SearchBar` 컴포넌트가 사용되는 페이지 별로 스타일 `variants`를 추가했습니다.
   - `header`: 헤더에 사용되는 서치바
   - `community`: 커뮤니티 페이지에서 게시글 검색에 사용되는 서치바
   - `detail`: 디테일 페이지에서 작품 검색 시 사용되는 서치바
   <img src="https://github.com/user-attachments/assets/00d88cc2-8c42-42cf-93da-b52bfb310efa" width="50%" />

<br/>

- `detail` 서치바에서는 기존 피그마에 있는 '취소' 보다는 `Close` 아이콘이 UI/UX 면에서 좋을 것 같아서 `Close` 아이콘으로 넣었습니다.  
   - `취소`
      <img src="https://github.com/user-attachments/assets/bc7a4f0f-01c6-4f0b-8a76-52321fcebc07" width="70%" />
   - `Close` 아이콘
      <img src="https://github.com/user-attachments/assets/95dd5799-3cf8-4d58-bd95-1d6bdd581a1d" width="50%" />

<br/>

### 테스트
- 로컬에서 정상 동작 확인했습니다.

<br/><br/>

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 의도한 대로 동작하는지 테스트를 했습니다.
- [x] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.
