### PR TITLE
[feat] CUL-180: Carousel 컴포넌트 개발

### DIFF
--- a/app/(main-layout)/page.tsx
+++ b/app/(main-layout)/page.tsx
@@ -1,9 +1,5 @@
 const Home = () => {
-  return (
-    <div>
-      <h1>/ (index)</h1>
-    </div>
-  );
+  return <div className='p-[20px_0px_20px_20px] lg:p-[40px]'></div>;
 };
 
 export default Home;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "boring-avatars": "^1.11.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "embla-carousel-react": "^8.5.2",
         "framer-motion": "^12.5.0",
         "next": "^14.2.24",
         "prettier-plugin-tailwindcss": "^0.6.11",
@@ -2088,6 +2089,34 @@
       "integrity": "sha512-wjT2O4hX+wdWPJ76gWSkMhcHAV2PTMX+QetUCPYEdCIe+cxmgzzSSiGRCKW8nuh4mwKZlpv0xvoW7OF2X+wmHg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.5.2.tgz",
+      "integrity": "sha512-xQ9oVLrun/eCG/7ru3R+I5bJ7shsD8fFwLEY7yPe27/+fDHCNj0OT5EoG5ZbFyOxOcG6yTwW8oTz/dWyFnyGpg==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.5.2.tgz",
+      "integrity": "sha512-Tmx+uY3MqseIGdwp0ScyUuxpBgx5jX1f7od4Cm5mDwg/dptEiTKf9xp6tw0lZN2VA9JbnVMl/aikmbc53c6QFA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.5.2",
+        "embla-carousel-reactive-utils": "8.5.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.5.2.tgz",
+      "integrity": "sha512-QC8/hYSK/pEmqEdU1IO5O+XNc/Ptmmq7uCB44vKplgLKhB/l0+yvYx0+Cv0sF6Ena8Srld5vUErZkT+yTahtDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.5.2"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "boring-avatars": "^1.11.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "embla-carousel-react": "^8.5.2",
     "framer-motion": "^12.5.0",
     "next": "^14.2.24",
     "prettier-plugin-tailwindcss": "^0.6.11",

--- a/src/components/Common/Carousel.tsx
+++ b/src/components/Common/Carousel.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import * as React from 'react';
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from 'embla-carousel-react';
+
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/common/Button';
+import Icon from '@/icons/Icon';
+
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
+
+type CarouselProps = {
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: 'horizontal' | 'vertical';
+  setApi?: (api: CarouselApi) => void;
+};
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext);
+
+  if (!context) {
+    throw new Error('useCarousel must be used within a <Carousel />');
+  }
+
+  return context;
+}
+
+const Carousel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      orientation = 'horizontal',
+      opts,
+      setApi,
+      plugins,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [carouselRef, api] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === 'horizontal' ? 'x' : 'y',
+      },
+      plugins
+    );
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+    const [canScrollNext, setCanScrollNext] = React.useState(false);
+
+    const onSelect = React.useCallback((api: CarouselApi) => {
+      if (!api) {
+        return;
+      }
+
+      setCanScrollPrev(api.canScrollPrev());
+      setCanScrollNext(api.canScrollNext());
+    }, []);
+
+    const scrollPrev = React.useCallback(() => {
+      api?.scrollPrev();
+    }, [api]);
+
+    const scrollNext = React.useCallback(() => {
+      api?.scrollNext();
+    }, [api]);
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'ArrowLeft') {
+          event.preventDefault();
+          scrollPrev();
+        } else if (event.key === 'ArrowRight') {
+          event.preventDefault();
+          scrollNext();
+        }
+      },
+      [scrollPrev, scrollNext]
+    );
+
+    React.useEffect(() => {
+      if (!api || !setApi) {
+        return;
+      }
+
+      setApi(api);
+    }, [api, setApi]);
+
+    React.useEffect(() => {
+      if (!api) {
+        return;
+      }
+
+      onSelect(api);
+      api.on('reInit', onSelect);
+      api.on('select', onSelect);
+
+      return () => {
+        api?.off('select', onSelect);
+      };
+    }, [api, onSelect]);
+
+    return (
+      <CarouselContext.Provider
+        value={{
+          carouselRef,
+          api: api,
+          opts,
+          orientation:
+            orientation || (opts?.axis === 'y' ? 'vertical' : 'horizontal'),
+          scrollPrev,
+          scrollNext,
+          canScrollPrev,
+          canScrollNext,
+        }}
+      >
+        <div
+          ref={ref}
+          onKeyDownCapture={handleKeyDown}
+          className={cn('relative', className)}
+          role='region'
+          aria-roledescription='carousel'
+          {...props}
+        >
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    );
+  }
+);
+Carousel.displayName = 'Carousel';
+
+const CarouselContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel();
+
+  return (
+    <div ref={carouselRef} className='overflow-hidden'>
+      <div
+        ref={ref}
+        className={cn(
+          'flex',
+          orientation === 'horizontal' ? '-ml-4' : '-mt-4 flex-col',
+          className
+        )}
+        {...props}
+      />
+    </div>
+  );
+});
+CarouselContent.displayName = 'CarouselContent';
+
+const CarouselItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel();
+
+  return (
+    <div
+      ref={ref}
+      role='group'
+      aria-roledescription='slide'
+      className={cn(
+        'min-w-0 shrink-0 grow-0 basis-full',
+        orientation === 'horizontal' ? 'pl-4' : 'pt-4',
+        className
+      )}
+      {...props}
+    />
+  );
+});
+CarouselItem.displayName = 'CarouselItem';
+
+const CarouselPrevious = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = 'none', size = 'sm', ...props }, ref) => {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        'absolute h-[2.4rem] w-[2.4rem] rounded-full bg-[#ffffffee] shadow-md hover:bg-[#ffffffaa]',
+        orientation === 'horizontal'
+          ? '-left-5 top-[calc(50%-1.2rem)] -translate-y-1/2'
+          : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <Icon name='ARROW_LEFT' size={20} />
+      <span className='sr-only'>Previous slide</span>
+    </Button>
+  );
+});
+CarouselPrevious.displayName = 'CarouselPrevious';
+
+const CarouselNext = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = 'none', size = 'sm', ...props }, ref) => {
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        'absolute h-[2.4rem] w-[2.4rem] rounded-full bg-[#ffffffee] shadow-md hover:bg-[#ffffffaa]',
+        orientation === 'horizontal'
+          ? '-right-5 top-[calc(50%-1.2rem)] -translate-y-1/2'
+          : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <Icon name='ARROW_RIGHT' size={20} />
+      <span className='sr-only'>Next slide</span>
+    </Button>
+  );
+});
+CarouselNext.displayName = 'CarouselNext';
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+};

--- a/src/components/Common/EventCarousel.tsx
+++ b/src/components/Common/EventCarousel.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import formatDuration from '@/utils/formatDuration';
+import ContentCard from '@/components/common/ContentCard';
+import { cn } from '@/lib/utils';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '@/components/common/Carousel';
+
+interface EventCarouselProps {
+  isRankVisible?: boolean;
+  events: {
+    id: number;
+    title: string;
+    place: string;
+    startDate: string;
+    endDate: string;
+    imageUrl: string;
+  }[];
+}
+
+const EventCarousel = ({
+  isRankVisible = false,
+  events,
+}: EventCarouselProps) => {
+  const [windowWidth, setWindowWidth] = useState<number>(
+    typeof window !== 'undefined' ? window.innerWidth : 1024
+  );
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const handleResize = () => setWindowWidth(window.innerWidth);
+      handleResize();
+      window.addEventListener('resize', handleResize);
+      return () => window.removeEventListener('resize', handleResize);
+    }
+  }, []);
+
+  return (
+    <Carousel
+      opts={{
+        align: 'start',
+        loop: true,
+        slidesToScroll: windowWidth > 1024 ? 6 : 1,
+      }}
+    >
+      <CarouselContent
+        className={cn('-ml-3', windowWidth < 1024 && 'overflow-visible')}
+      >
+        {events.map(
+          ({ title, place, startDate, endDate, imageUrl, id }, index) => (
+            <CarouselItem
+              key={id}
+              className='max-w-[150px] flex-none pl-3 lg:max-w-none lg:flex-grow lg:basis-1/6'
+            >
+              <ContentCard
+                index={index}
+                id={id}
+                title={title}
+                place={place}
+                date={formatDuration(startDate, endDate)}
+                src={imageUrl}
+                isRankVisible={isRankVisible}
+              />
+            </CarouselItem>
+          )
+        )}
+      </CarouselContent>
+      {windowWidth > 1024 && (
+        <CarouselPrevious className='-translate-y-[70px]' />
+      )}
+      {windowWidth > 1024 && <CarouselNext className='-translate-y-[70px]' />}
+    </Carousel>
+  );
+};
+
+export default EventCarousel;

--- a/src/components/Common/EventCarousel.tsx
+++ b/src/components/Common/EventCarousel.tsx
@@ -28,9 +28,7 @@ const EventCarousel = ({
   isRankVisible = false,
   events,
 }: EventCarouselProps) => {
-  const [windowWidth, setWindowWidth] = useState<number>(
-    typeof window !== 'undefined' ? window.innerWidth : 1024
-  );
+  const [windowWidth, setWindowWidth] = useState<number | null>(null);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -46,11 +44,15 @@ const EventCarousel = ({
       opts={{
         align: 'start',
         loop: true,
-        slidesToScroll: windowWidth > 1024 ? 6 : 1,
+        dragFree: windowWidth && windowWidth > 1024 ? false : true,
+        slidesToScroll: windowWidth && windowWidth > 1024 ? 6 : 1,
       }}
     >
       <CarouselContent
-        className={cn('-ml-3', windowWidth < 1024 && 'overflow-visible')}
+        className={cn(
+          '-ml-3',
+          windowWidth && windowWidth < 1024 && 'overflow-visible'
+        )}
       >
         {events.map(
           ({ title, place, startDate, endDate, imageUrl, id }, index) => (
@@ -71,10 +73,12 @@ const EventCarousel = ({
           )
         )}
       </CarouselContent>
-      {windowWidth > 1024 && (
+      {windowWidth && windowWidth > 1024 && (
         <CarouselPrevious className='-translate-y-[70px]' />
       )}
-      {windowWidth > 1024 && <CarouselNext className='-translate-y-[70px]' />}
+      {windowWidth && windowWidth > 1024 && (
+        <CarouselNext className='-translate-y-[70px]' />
+      )}
     </Carousel>
   );
 };

--- a/src/components/Common/NavigationBar.tsx
+++ b/src/components/Common/NavigationBar.tsx
@@ -37,7 +37,7 @@ const NavigationBar = ({ children }: { children: React.ReactNode }) => {
           'z-40'
         )}
       >
-        <div className='p-[40px]'>{children}</div>
+        <div>{children}</div>
       </div>
     </div>
   );

--- a/src/components/Common/NavigationBar.tsx
+++ b/src/components/Common/NavigationBar.tsx
@@ -18,7 +18,7 @@ const NavigationBar = ({ children }: { children: React.ReactNode }) => {
   };
 
   return (
-    <div className='z-[50]'>
+    <div>
       <Header onToggleSidebar={toggleSidebar} />
       <Sidebar
         currentUrl={pathname}
@@ -27,11 +27,15 @@ const NavigationBar = ({ children }: { children: React.ReactNode }) => {
             ? MYPAGE_SIDEBAR_ITEMS
             : GENERAL_SIDEBAR_ITEMS
         }
-        className='fixed left-0 top-20'
+        className='fixed left-0 top-20 z-50'
         isCollapsed={isCollapsed}
       />
       <div
-        className={cn(isCollapsed ? 'pl-[90px]' : 'pl-[200px]', 'pt-[80px]')}
+        className={cn(
+          isCollapsed ? 'pl-[90px]' : 'pl-[200px]',
+          'pt-[80px]',
+          'z-40'
+        )}
       >
         <div className='p-[40px]'>{children}</div>
       </div>

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -5,7 +5,7 @@ const Card = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('w-40', className)} {...props} />
+  <div ref={ref} className={cn(className)} {...props} />
 ));
 Card.displayName = 'Card';
 
@@ -28,7 +28,7 @@ const CardTitle = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'pl-1 pt-1.5 text-body1 font-semibold leading-none tracking-tight',
+      'my-2 text-body1 font-semibold leading-none tracking-tight',
       className
     )}
     {...props}
@@ -40,7 +40,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('pl-1 pt-3', className)} {...props} />
+  <div ref={ref} className={cn('pl-1 pt-2', className)} {...props} />
 ));
 CardContent.displayName = 'CardContent';
 

--- a/src/components/common/ContentCard.tsx
+++ b/src/components/common/ContentCard.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { useState } from 'react';
+
+import { useState, useEffect, useRef } from 'react';
 import {
   Card,
   CardContent,
@@ -7,54 +8,107 @@ import {
   CardTitle,
 } from '@/components/common/Card';
 import Icon from '@/icons/Icon';
+import Link from 'next/link';
 
 interface ContentProps {
+  index: number;
+  id: number;
   src?: string;
   title: string;
   place: string;
   date: string;
+  isRankVisible?: boolean;
 }
 
-const ContentCard = ({ src, title, place, date }: ContentProps) => {
+const ContentCard = ({
+  index,
+  id,
+  src,
+  title,
+  place,
+  date,
+  isRankVisible = false,
+}: ContentProps) => {
   const [liked, setLiked] = useState(false);
+  const [cardWidth, setCardWidth] = useState<number>(
+    typeof window !== 'undefined' ? window.innerWidth : 150
+  );
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const onClickLike = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setLiked((prev) => !prev);
+  };
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const updateWidth = () => {
+        if (cardRef.current) {
+          setCardWidth(cardRef.current.offsetWidth);
+        }
+      };
+
+      updateWidth();
+      window.addEventListener('resize', updateWidth);
+
+      return () => {
+        window.removeEventListener('resize', updateWidth);
+      };
+    }
+  }, []);
 
   return (
-    <Card>
-      <CardHeader>
-        <div className='relative'>
-          <img
-            src={src || '/assets/logo-icon.svg'}
-            className='w-40 h-56 rounded-10'
-            alt='공연 이미지'
-          />
-
-          <button
-            onClick={() => setLiked(!liked)}
-            className='absolute text-xl transition-transform bottom-2 right-2 hover:scale-110'
-          >
-            {liked ? (
-              <Icon
-                name='LIKE'
-                size={18}
-                className='fill-primary stroke-none'
-              />
-            ) : (
-              <Icon
-                name='LIKE'
-                size={18}
-                className='stroke-border hover:stroke-primary'
-              />
+    <Card ref={cardRef} className='transition-all duration-300'>
+      <Link href={`/events/${id}`}>
+        <CardHeader>
+          <div className='group relative overflow-hidden rounded-10'>
+            <img
+              src={src || '/assets/logo-icon.svg'}
+              className='aspect-[3/4] w-full rounded-10 transition-transform duration-300 group-hover:scale-110'
+              alt='공연 이미지'
+            />
+            {isRankVisible && (
+              <div className='absolute bottom-0 left-0 h-1/3 w-full rounded-10 bg-gradient-to-t from-black/60 to-transparent'></div>
             )}
-          </button>
-        </div>
-
-        <CardTitle>{title}</CardTitle>
-      </CardHeader>
-
-      <CardContent>
-        <p className='text-sm text-text'>{place}</p>
-        <p className='text-caption text-text-sub'>{date}</p>
-      </CardContent>
+            <button
+              onClick={onClickLike}
+              className='absolute bottom-2 right-2 text-xl transition-transform hover:scale-110'
+            >
+              {liked ? (
+                <Icon
+                  name='LIKE'
+                  size={cardWidth > 150 ? 22 : 18}
+                  className='fill-primary stroke-none'
+                />
+              ) : (
+                <Icon
+                  name='LIKE'
+                  size={cardWidth > 150 ? 22 : 18}
+                  className='stroke-border hover:stroke-primary'
+                />
+              )}
+            </button>
+            {isRankVisible && (
+              <div
+                className='absolute font-semibold text-white'
+                style={{
+                  fontSize: cardWidth * 0.2,
+                  bottom: 0,
+                  left: cardWidth * 0.06,
+                  textShadow: '2px 2px 4px rgba(0, 0, 0, 0.3)',
+                }}
+              >
+                {index + 1}
+              </div>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className='h-[140px]'>
+          <CardTitle className='line-clamp-2'>{title}</CardTitle>
+          <p className='line-clamp-2 text-sm text-text'>{place}</p>
+          <p className='line-clamp-2 text-caption text-text-sub'>{date}</p>
+        </CardContent>
+      </Link>
     </Card>
   );
 };

--- a/src/components/common/ContentCard.tsx
+++ b/src/components/common/ContentCard.tsx
@@ -30,9 +30,7 @@ const ContentCard = ({
   isRankVisible = false,
 }: ContentProps) => {
   const [liked, setLiked] = useState(false);
-  const [cardWidth, setCardWidth] = useState<number>(
-    typeof window !== 'undefined' ? window.innerWidth : 150
-  );
+  const [cardWidth, setCardWidth] = useState<number | null>(null);
   const cardRef = useRef<HTMLDivElement>(null);
 
   const onClickLike = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -77,18 +75,18 @@ const ContentCard = ({
               {liked ? (
                 <Icon
                   name='LIKE'
-                  size={cardWidth > 150 ? 22 : 18}
+                  size={cardWidth && cardWidth > 150 ? 22 : 18}
                   className='fill-primary stroke-none'
                 />
               ) : (
                 <Icon
                   name='LIKE'
-                  size={cardWidth > 150 ? 22 : 18}
+                  size={cardWidth && cardWidth > 150 ? 22 : 18}
                   className='stroke-border hover:stroke-primary'
                 />
               )}
             </button>
-            {isRankVisible && (
+            {isRankVisible && cardWidth && (
               <div
                 className='absolute font-semibold text-white'
                 style={{

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -35,7 +35,7 @@ const Header = ({ onToggleSidebar }: HeaderProps) => {
   }, []);
 
   return (
-    <header className='fixed left-0 top-0 flex h-20 w-full items-center justify-between bg-bg'>
+    <header className='fixed left-0 top-0 z-50 flex h-20 w-full items-center justify-between bg-bg'>
       <div className='flex-[3]'>
         <div className='mx-[34px] flex w-[280px] gap-10'>
           <button onClick={onToggleSidebar}>

--- a/src/data/mockEvent.ts
+++ b/src/data/mockEvent.ts
@@ -1,0 +1,405 @@
+export const mockPerformances = [
+  {
+    id: 1,
+    type: 'performance',
+    title: '뮤지컬 <모리스>',
+    place: '인터파크 서경스퀘어 스콘 1관',
+    startDate: '2025.03.07',
+    endDate: '2025.05.25',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25001387_p.gif',
+  },
+  {
+    id: 2,
+    type: 'performance',
+    title: '뮤지컬 지킬앤하이드 (Jekyll ＆ Hyde) - 20주년',
+    place: '블루스퀘어 신한카드홀',
+    startDate: '2024.11.29',
+    endDate: '2025.05.18',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/24/24013928_p.gif',
+  },
+  {
+    id: 3,
+    type: 'performance',
+    title: '뮤지컬 〈알라딘〉 한국 초연 (ALADDIN The Musical)',
+    place: '샤롯데씨어터',
+    startDate: '2024.11.22',
+    endDate: '2025.06.22',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/24/24012498_p.gif',
+  },
+  {
+    id: 4,
+    type: 'performance',
+    title: '뮤지컬 〈라이카〉',
+    place: '두산아트센터 연강홀',
+    startDate: '2025.03.14',
+    endDate: '2025.05.18',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25001462_p.gif',
+  },
+  {
+    id: 5,
+    type: 'performance',
+    title: '뮤지컬 〈도리안 그레이〉',
+    place: '홍익대 대학로 아트센터 대극장',
+    startDate: '2025.03.30',
+    endDate: '2025.06.08',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25001547_p.gif',
+  },
+  {
+    id: 6,
+    type: 'performance',
+    title: '콜드플레이 내한공연',
+    place: '고양종합운동장 주경기장(자세히)',
+    startDate: '2025.04.16',
+    endDate: '2025.04.25',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/24/24013437_p.gif',
+  },
+  {
+    id: 7,
+    type: 'performance',
+    title: '서울스프링페스타 WONDER SHOW_2차 티켓',
+    place: '서울월드컵경기장',
+    startDate: '2025.04.30',
+    endDate: '2025.04.30',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25002908_p.gif',
+  },
+  {
+    id: 8,
+    type: 'performance',
+    title: '2025 이영현 콘서트 ＂나의 노래가 필요한 너에게＂ - 봄',
+    place: '블루스퀘어 SOL트래블홀',
+    startDate: '2025.05.30',
+    endDate: '2025.06.01',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25004620_p.gif',
+  },
+  {
+    id: 9,
+    type: 'performance',
+    title: '2025 N.Flying LIVE ‘＆CON4 : FULL CIRCLE’',
+    place: '올림픽공원 올림픽홀',
+    startDate: '2025.05.09',
+    endDate: '2025.05.11',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25004056_p.gif',
+  },
+  {
+    id: 10,
+    type: 'performance',
+    title: '2025 ZEROBASEONE FAN-CON［BLUE MANSION］',
+    place: 'KSPO DOME',
+    startDate: '2025.04.18',
+    endDate: '2025.04.20',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25003660_p.gif',
+  },
+  {
+    id: 11,
+    type: 'performance',
+    title: '뮤지컬 <모리스>',
+    place: '인터파크 서경스퀘어 스콘 1관',
+    startDate: '2025.03.07',
+    endDate: '2025.05.25',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25001387_p.gif',
+  },
+  {
+    id: 12,
+    type: 'performance',
+    title: '뮤지컬 지킬앤하이드 (Jekyll ＆ Hyde) - 20주년',
+    place: '블루스퀘어 신한카드홀',
+    startDate: '2024.11.29',
+    endDate: '2025.05.18',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/24/24013928_p.gif',
+  },
+  {
+    id: 13,
+    type: 'performance',
+    title: '뮤지컬 〈알라딘〉 한국 초연 (ALADDIN The Musical)',
+    place: '샤롯데씨어터',
+    startDate: '2024.11.22',
+    endDate: '2025.06.22',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/24/24012498_p.gif',
+  },
+  {
+    id: 14,
+    type: 'performance',
+    title: '뮤지컬 〈라이카〉',
+    place: '두산아트센터 연강홀',
+    startDate: '2025.03.14',
+    endDate: '2025.05.18',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25001462_p.gif',
+  },
+  {
+    id: 15,
+    type: 'performance',
+    title: '뮤지컬 〈도리안 그레이〉',
+    place: '홍익대 대학로 아트센터 대극장',
+    startDate: '2025.03.30',
+    endDate: '2025.06.08',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25001547_p.gif',
+  },
+  {
+    id: 16,
+    type: 'performance',
+    title: '콜드플레이 내한공연',
+    place: '고양종합운동장 주경기장(자세히)',
+    startDate: '2025.04.16',
+    endDate: '2025.04.25',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/24/24013437_p.gif',
+  },
+  {
+    id: 17,
+    type: 'performance',
+    title: '서울스프링페스타 WONDER SHOW_2차 티켓',
+    place: '서울월드컵경기장',
+    startDate: '2025.04.30',
+    endDate: '2025.04.30',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25002908_p.gif',
+  },
+  {
+    id: 18,
+    type: 'performance',
+    title: '2025 이영현 콘서트 ＂나의 노래가 필요한 너에게＂ - 봄',
+    place: '블루스퀘어 SOL트래블홀',
+    startDate: '2025.05.30',
+    endDate: '2025.06.01',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25004620_p.gif',
+  },
+  {
+    id: 19,
+    type: 'performance',
+    title: '2025 N.Flying LIVE ‘＆CON4 : FULL CIRCLE’',
+    place: '올림픽공원 올림픽홀',
+    startDate: '2025.05.09',
+    endDate: '2025.05.11',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25004056_p.gif',
+  },
+  {
+    id: 20,
+    type: 'performance',
+    title: '2025 ZEROBASEONE FAN-CON［BLUE MANSION］',
+    place: 'KSPO DOME',
+    startDate: '2025.04.18',
+    endDate: '2025.04.20',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25003660_p.gif',
+  },
+];
+
+export const mockExhibitions = [
+  {
+    id: 21,
+    type: 'exhibition',
+    title: '크리스챤 디올 : 디자이너 오브 드림스',
+    place: '동대문디자인플라자 아트홀 1관',
+    startDate: '2025.04.19',
+    endDate: '2025.07.13',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25003752_p.gif',
+  },
+  {
+    id: 22,
+    type: 'exhibition',
+    title: '인상파, 모네에서 미국으로: 빛, 바다를 건너다',
+    place: '더현대 서울 ALT. 1',
+    startDate: '2025.02.15',
+    endDate: '2025.05.26',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25001149_p.gif',
+  },
+  {
+    id: 23,
+    type: 'exhibition',
+    title: '［얼리버드］현대카드 컬처프로젝트 29 톰 삭스 전',
+    place: '동대문디자인플라자 뮤지엄',
+    startDate: '2025.04.25',
+    endDate: '2025.07.25',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25002387_p.gif',
+  },
+  {
+    id: 24,
+    type: 'exhibition',
+    title: '불멸의 화가 반 고흐 in 대전',
+    place: '대전시립미술관',
+    startDate: '2025.03.25',
+    endDate: '2025.06.22',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25003731_p.gif',
+  },
+  {
+    id: 25,
+    type: 'exhibition',
+    title: '빛의 거장 카라바조 ＆ 바로크의 얼굴들',
+    place: '예술의전당 한가람미술관 2층',
+    startDate: '2024.11.09',
+    endDate: '2025.04.06',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/24/24016040_p.gif',
+  },
+  {
+    id: 26,
+    type: 'exhibition',
+    title: '［20% 할인＋무하 음료 증정］알폰스 무하 원화전',
+    place: '마이아트뮤지엄',
+    startDate: '2025.03.20',
+    endDate: '2025.07.13',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25001911_p.gif',
+  },
+  {
+    id: 27,
+    type: 'exhibition',
+    title: '［북촌］2025년 3월~4월_어둠속의대화(DIALOGUE IN THE DARK)',
+    place: '북촌 어둠속의대화',
+    startDate: '2010.01.20',
+    endDate: '오픈런',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/24/24017362_p.gif',
+  },
+  {
+    id: 28,
+    type: 'exhibition',
+    title: '［예매할인 20% / 6~7월］ 워너 브롱크호스트',
+    place: '그라운드시소 서촌',
+    startDate: '2025.06.01',
+    endDate: '2025.07.31',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25003628_p.gif',
+  },
+  {
+    id: 29,
+    type: 'exhibition',
+    title: '［최대 30%할인］ 디즈니 100년 특별전',
+    place: 'K현대미술관',
+    startDate: '2024.10.18',
+    endDate: '2025.06.01',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/24/24011855_p.gif',
+  },
+  {
+    id: 30,
+    type: 'exhibition',
+    title: '［얼리버드］ 퓰리처상 사진전 대구',
+    place: '뮤씨엄 대구점',
+    startDate: '2025.04.25',
+    endDate: '2025.06.30',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25003889_p.gif',
+  },
+  {
+    id: 31,
+    type: 'exhibition',
+    title: '크리스챤 디올 : 디자이너 오브 드림스',
+    place: '동대문디자인플라자 아트홀 1관',
+    startDate: '2025.04.19',
+    endDate: '2025.07.13',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25003752_p.gif',
+  },
+  {
+    id: 32,
+    type: 'exhibition',
+    title: '인상파, 모네에서 미국으로: 빛, 바다를 건너다',
+    place: '더현대 서울 ALT. 1',
+    startDate: '2025.02.15',
+    endDate: '2025.05.26',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25001149_p.gif',
+  },
+  {
+    id: 33,
+    type: 'exhibition',
+    title: '［얼리버드］현대카드 컬처프로젝트 29 톰 삭스 전',
+    place: '동대문디자인플라자 뮤지엄',
+    startDate: '2025.04.25',
+    endDate: '2025.07.25',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25002387_p.gif',
+  },
+  {
+    id: 34,
+    type: 'exhibition',
+    title: '불멸의 화가 반 고흐 in 대전',
+    place: '대전시립미술관',
+    startDate: '2025.03.25',
+    endDate: '2025.06.22',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25003731_p.gif',
+  },
+  {
+    id: 35,
+    type: 'exhibition',
+    title: '빛의 거장 카라바조 ＆ 바로크의 얼굴들',
+    place: '예술의전당 한가람미술관 2층',
+    startDate: '2024.11.09',
+    endDate: '2025.04.06',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/24/24016040_p.gif',
+  },
+  {
+    id: 36,
+    type: 'exhibition',
+    title: '［20% 할인＋무하 음료 증정］알폰스 무하 원화전',
+    place: '마이아트뮤지엄',
+    startDate: '2025.03.20',
+    endDate: '2025.07.13',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25001911_p.gif',
+  },
+  {
+    id: 37,
+    type: 'exhibition',
+    title: '［북촌］2025년 3월~4월_어둠속의대화(DIALOGUE IN THE DARK)',
+    place: '북촌 어둠속의대화',
+    startDate: '2010.01.20',
+    endDate: '오픈런',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/24/24017362_p.gif',
+  },
+  {
+    id: 38,
+    type: 'exhibition',
+    title: '［예매할인 20% / 6~7월］ 워너 브롱크호스트',
+    place: '그라운드시소 서촌',
+    startDate: '2025.06.01',
+    endDate: '2025.07.31',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25003628_p.gif',
+  },
+  {
+    id: 39,
+    type: 'exhibition',
+    title: '［최대 30%할인］ 디즈니 100년 특별전',
+    place: 'K현대미술관',
+    startDate: '2024.10.18',
+    endDate: '2025.06.01',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/24/24011855_p.gif',
+  },
+  {
+    id: 40,
+    type: 'exhibition',
+    title: '［얼리버드］ 퓰리처상 사진전 대구',
+    place: '뮤씨엄 대구점',
+    startDate: '2025.04.25',
+    endDate: '2025.06.30',
+    imageUrl:
+      'https://ticketimage.interpark.com/Play/image/large/25/25003889_p.gif',
+  },
+];

--- a/src/utils/formatDuration.ts
+++ b/src/utils/formatDuration.ts
@@ -1,0 +1,14 @@
+import formatDate from '@/utils/formatDate';
+
+const formatDuration = (startDate: string, endDate?: string): string => {
+  const [formattedStartDate, formattedEndDate] = [
+    formatDate(startDate).slice(0, 10),
+    endDate && formatDate(endDate).slice(0, 10),
+  ];
+  if (!formattedEndDate || formattedStartDate === formattedEndDate) {
+    return formattedStartDate;
+  }
+  return `${formattedStartDate}-${formattedEndDate}`;
+};
+
+export default formatDuration;


### PR DESCRIPTION
# [feat] CUL-180: Carousel 컴포넌트 개발

<br/>

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] develop 브랜치에서 최신 데이터를 가져오기 위한 PR

<br/><br/>

## PR 상세

### 주요 변경 사항
- `Card`, `ContentCard`의 디자인을 수정하고 기능을 추가했습니다.
  - `Card`: 고정된 `width`를 삭제해 너비가 변하도록 수정, `isRankVIsible`가 `true`일 때 순위를 보여줌
  - `ContentCard`: `Link` 태그 추가, hover 시 이미지 확대, 카드 너비에 따라 좋아요 아이콘 크기가 바뀜

- `Carousel` 컴포넌트를 개발했습니다.
  - shadcn-ui의 carousel을 사용 (`embla-carousel-react` 설치)

- `Carousel` 컴포넌트를 사용해 `EventCarousel`을 개발했습니다. (이벤트 목록을 보여주는 캐러셀)
  - 무한 캐러셀 (마지막 이벤트까지 조회한 후 처음으로 돌아감)
  - 화면 너비에 따라 UI가 바뀌도록 구현
    - `1024px` 이상일 때: 캐러셀 버튼 노출(버튼 클릭 or 스와이프로 슬라이드 넘김), 한 줄에 6개의 이벤트 (비율에 따라 카드 너비 변화)
    - `1024px` 미만일 때: 캐러셀 버튼 숨김(스와이프로 슬라이드 넘김), 카드 너비 150px로 고정

- `formatDuration` 함수를 추가했습니다. (시작일, 종료일을 기간으로 반환하는 함수)
  - `startDate`, `endDate`를 `yyyy.MM.dd` 형식으로 포맷
  - `[startDate]-[endDate]`를 반환 (`2025.04.04-2025.04.10`)
  - `startDate`와 `endDate`가 같거나 `endDate`가 없는 경우 `startDate`만 반환 (`2025.04.04`)

- `mockEvent`를 추가했습니다. (이벤트 mockData, 출처: [**인터파크 티켓**](https://tickets.interpark.com/contents/genre/musical))

<br/>

### 스크린샷
- `EventCarousel`의 순위 노출 여부에 따른 UI
![image](https://github.com/user-attachments/assets/212fb991-49d0-4351-b1ae-680c83619380)
![image](https://github.com/user-attachments/assets/f327fdfa-17dc-44fc-bf4b-1ee122e10a7f)

- `EventCarousel`의 기본 동작
![녹화_2025_04_04_01_32_17_93](https://github.com/user-attachments/assets/fcb481ee-3268-4e78-978b-f4fa9b9edc35)

- 화면 너비에 따른 `EventCarousel` UI 변화
![녹화_2025_04_04_01_31_59_100](https://github.com/user-attachments/assets/8b0cf000-0998-415f-960e-179ee67b80dd)


<br/>

### 테스트
- 로컬에서 정상 동작 확인했습니다. (`Card`, `ContentCard`, `Carousel`, `EventCarousel`)

<br/>

### 참고사항
- `Carousel` 관련 문서 링크 첨부합니다!
  - 사용 방법: [**shadcn-ui/carousel**](https://ui.shadcn.com/docs/components/carousel)
  - 옵션: [**embla-carousel**](https://www.embla-carousel.com/api/options/)

<br/><br/>

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 의도한 대로 동작하는지 테스트를 했습니다.
- [ ] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.

<br/>

## 다음 작업
- `EventCarousel`을 홈 화면에 적용하겠습니다.

