### PR TITLE
[fix] CUL-200: 프로필 수정 페이지 및 버튼 UI 피드백 반영

### DIFF
--- a/app/(main-layout)/my/profile/page.tsx
+++ b/app/(main-layout)/my/profile/page.tsx
@@ -37,11 +37,11 @@ const Profile = () => {
   };
 
   return (
-    <div className='mx-auto flex w-[400px] flex-col items-center justify-center gap-3 p-5'>
+    <div className='flex flex-col items-center justify-center gap-3 p-5 mx-auto w-96'>
       <p className='text-h3'>회원 정보 수정</p>
       <AvatarProfile />
 
-      <form action='' className='flex flex-col gap-5 p-2'>
+      <form action='' className='flex flex-col gap-5 p-3'>
         <Input
           type='email'
           placeholder='기존 이메일 값'
@@ -60,7 +60,7 @@ const Profile = () => {
           onChange={(e) => setNickname(e.target.value)}
         />
 
-        <div className='pt-2'>
+        <div className='py-4'>
           <p className='pb-1'>관심 장르 설정</p>
           {GENRES.map((genre, i) => (
             <ToggleButton
@@ -73,7 +73,7 @@ const Profile = () => {
         </div>
       </form>
 
-      <div className='flex w-full gap-3'>
+      <div className='flex w-[95%] gap-3'>
         <Button
           variant='secondary'
           children='취소'

--- a/app/(main-layout)/my/profile/page.tsx
+++ b/app/(main-layout)/my/profile/page.tsx
@@ -2,7 +2,6 @@
 import { useState } from 'react';
 import { Button } from '@/components/common/button/Button';
 import Input from '@/components/common/Input';
-import Icon from '@/icons/Icon';
 import ToggleButton from '@/components/common/button/ToggleButton';
 import AvatarProfile from '@/components/common/AvatarProfile';
 import { GENRES } from '@/constants/event';
@@ -11,25 +10,13 @@ import { useModalStore } from '@/stores/useModalStore';
 
 const Profile = () => {
   const { openModal } = useModalStore();
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
   const [nickname, setNickname] = useState('');
   const [selectedGenres, setSelectedGenres] = useState<GenreName[]>([
     '전시',
     '연극',
     '무용',
   ]);
-
-  // 비밀번호 아이콘 핸들러
-  const togglePasswordVisibility = (type: 'password' | 'confirmPassword') => {
-    if (type === 'password') {
-      setShowPassword((prev) => !prev);
-      console.log('비밀번호 아이콘 클릭');
-    } else {
-      setShowConfirmPassword((prev) => !prev);
-      console.log('비밀번호 확인 아이콘 클릭');
-    }
-  };
 
   // 중복 확인
   const onCheckDuplicate = (e: React.MouseEvent) => {
@@ -61,41 +48,6 @@ const Profile = () => {
           readOnly
           onFocus={(e) => e.target.blur()}
         />
-        <Input
-          type='password'
-          placeholder='비밀번호'
-          icon={
-            <button
-              type='button'
-              onClick={() => togglePasswordVisibility('password')}
-              className='flex cursor-pointer'
-            >
-              <Icon
-                name={showPassword ? 'EYE' : 'EYE_SLASHED'}
-                size={20}
-                className='stroke-text-sub stroke-[2px]'
-              />
-            </button>
-          }
-        />
-        <Input
-          type='password'
-          placeholder='비밀번호 확인'
-          icon={
-            <button
-              type='button'
-              onClick={() => togglePasswordVisibility('confirmPassword')}
-              className='flex cursor-pointer'
-            >
-              <Icon
-                name={showConfirmPassword ? 'EYE' : 'EYE_SLASHED'}
-                size={20}
-                className='stroke-text-sub stroke-[2px]'
-              />
-            </button>
-          }
-        />
-
         <Input
           type='text'
           icon={

--- a/app/(main-layout)/my/profile/page.tsx
+++ b/app/(main-layout)/my/profile/page.tsx
@@ -37,7 +37,7 @@ const Profile = () => {
   };
 
   return (
-    <div className='mx-auto flex w-[30%] flex-col items-center justify-center gap-3 p-5'>
+    <div className='mx-auto flex w-[400px] flex-col items-center justify-center gap-3 p-5'>
       <p className='text-h3'>회원 정보 수정</p>
       <AvatarProfile />
 

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -13,7 +13,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         <input
           type={type}
           className={cn(
-            'focus-visible:ring-ring flex h-9 w-full rounded-lg bg-bg-light px-4 py-1 pr-16 text-sm transition-colors placeholder:text-text-disabled focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
+            'focus-visible:ring-ring flex h-10 w-full rounded-lg bg-bg-light px-4 py-1 pr-16 text-sm transition-colors placeholder:text-text-disabled focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
           )}
           ref={ref}
           {...props}

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../../../lib/utils';
 
 const buttonVariants = cva(
-  'h-9 inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'h-10 inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-10 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {


### PR DESCRIPTION
# [fix] CUL-200: 프로필 수정 페이지 및 버튼 UI 피드백 반영

<br/>

## PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] develop 브랜치에서 최신 데이터를 가져오기 위한 PR

<br/><br/>

## PR 상세

### 주요 변경 사항
**@chopinoff  님의 피드백을 반영하여 UI 수정 작업 진행했습니다.**

<br/>

1. **Button 컴포넌트**
   - height: 36px(9) → **40px(10)**
   - round: md → **10**
   <img src="https://github.com/user-attachments/assets/cba9c871-c98a-4454-b09b-d258b5d2aa8f" width="400" />

2. **Input 컴포넌트**
   - height: 36px(9) → **40px(10)**
   <img src="https://github.com/user-attachments/assets/150a71e2-ddcc-4ff7-9659-64d7234e48d7" width="400" />

3. **프로필 수정 페이지**
   - 컨테이너 크기 고정
      - width: w-[30%] → **384px(96)**
    - 불필요한 입력 필드 제거
      - 비밀번호, 비밀번호 확인 input 제거
![프로필 페이지 UI 피드백 반영](https://github.com/user-attachments/assets/a66ba804-78fc-442a-ba1c-f0579d398e56)

<br/>

### 테스트
- 로컬에서 정상 동작 확인했습니다.

<br/>

### 참고사항
- 수정한 UI에 대한 리뷰 부탁드립니다.
- 프로필 수정 페이지의 컨텐츠 height 설정은 기본적으로 되어있는 상태라서 추가하지 않았습니다.
![image](https://github.com/user-attachments/assets/1bff2470-7762-4243-ad2b-f725bd56b709)

<br/><br/>

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 의도한 대로 동작하는지 테스트를 했습니다.
- [ ] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.
