### PR TITLE
[feat] CUL-283: 커뮤니티 - 전체 게시글 페이지 UI 구현

### DIFF
--- a/app/(main-layout)/community/[postId]/page.tsx
+++ b/app/(main-layout)/community/[postId]/page.tsx
@@ -1,0 +1,24 @@
+import CommentListToolbar from '@/components/page/community/CommentListToolbar';
+import CommentListItem from '@/components/page/community/CommentListItem';
+
+const Page = () => {
+  return (
+    <div>
+      <h1>게시글 상세 페이지</h1>
+
+      <CommentListToolbar commentCount={0} />
+      <CommentListItem
+        commentId={0}
+        postId={0}
+        content={''}
+        userId={0}
+        username={''}
+        profileCode={0}
+        createdAt={''}
+        updatedAt={''}
+      />
+    </div>
+  );
+};
+
+export default Page;

--- a/app/(main-layout)/community/page.tsx
+++ b/app/(main-layout)/community/page.tsx
@@ -2,7 +2,7 @@
 
 import PostListToolbar from '@/components/page/community/PostListToolbar';
 import PostListItem from '@/components/page/community/PostListItem';
-// 정렬 순서 바
+import SearchBar from '@/components/common/SearchBar';
 
 // 임시 유저 데이터
 const User = {
@@ -13,13 +13,38 @@ const User = {
 
 const Page = () => {
   return (
-    <div>
+    <div className='px-10 pt-5'>
       <h3 className='font-paperlogy text-[22px] font-normal'>커뮤니티</h3>
-
-      <div className='my-2 border border-lime-400 p-2'>
+      <div className='flex'>
+        <div className='ml-auto'>
+          <SearchBar variant='community' />
+        </div>
+      </div>
+      <div className='mt-2'>
         <PostListToolbar postCount={0} />
       </div>
-      <div className='my-2 border border-lime-400 p-2'>
+
+      <div>
+        <PostListItem
+          postId={0}
+          title={'게시글 제목임'}
+          content={'내용임'}
+          author={User}
+          hits={0}
+          likeCount={0}
+          commentCount={0}
+          createdAt={'123'}
+        />
+        <PostListItem
+          postId={0}
+          title={'게시글 제목임'}
+          content={'내용임'}
+          author={User}
+          hits={0}
+          likeCount={0}
+          commentCount={0}
+          createdAt={'123'}
+        />
         <PostListItem
           postId={0}
           title={'게시글 제목임'}

--- a/app/(main-layout)/community/page.tsx
+++ b/app/(main-layout)/community/page.tsx
@@ -1,7 +1,36 @@
+'use client';
+
+import PostListToolbar from '@/components/page/community/PostListToolbar';
+import PostListItem from '@/components/page/community/PostListItem';
+// 정렬 순서 바
+
+// 임시 유저 데이터
+const User = {
+  userId: 123,
+  username: '권보령',
+  profileCode: 123,
+};
+
 const Page = () => {
   return (
     <div>
-      <h1>/community</h1>
+      <h3 className='font-paperlogy text-[22px] font-normal'>커뮤니티</h3>
+
+      <div className='my-2 border border-lime-400 p-2'>
+        <PostListToolbar postCount={0} />
+      </div>
+      <div className='my-2 border border-lime-400 p-2'>
+        <PostListItem
+          postId={0}
+          title={'게시글 제목임'}
+          content={'내용임'}
+          author={User}
+          hits={0}
+          likeCount={0}
+          commentCount={0}
+          createdAt={'123'}
+        />
+      </div>
     </div>
   );
 };

--- a/app/(main-layout)/community/page.tsx
+++ b/app/(main-layout)/community/page.tsx
@@ -14,9 +14,11 @@ const User = {
 const Page = () => {
   return (
     <div className='px-10 pt-5'>
-      <h3 className='font-paperlogy text-[22px] font-normal'>커뮤니티</h3>
+      <h3 className='select-none font-paperlogy text-[22px] font-normal'>
+        커뮤니티
+      </h3>
       <div className='flex'>
-        <div className='ml-auto'>
+        <div className='ml-auto select-none'>
           <SearchBar variant='community' />
         </div>
       </div>

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 
 const dropdownButtonWidths = {
   default: 'w-32',
-  sm: 'w-24',
+  sm: 'w-26',
   lg: 'w-48',
   fit: 'w-fit',
 } as const;
@@ -114,7 +114,7 @@ const Dropdown = ({
           hideButtonPadding && 'p-0'
         )}
       >
-        <div>
+        <div className='select-none'>
           {type === 'select'
             ? (isSelected === menuItems[0].label && buttonText) || isSelected
             : buttonText}

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -12,7 +12,7 @@ const searchBarVariants = cva(
     variants: {
       variant: {
         header: 'bg-bg-light rounded-3xl',
-        community: 'bg-white rounded-5 border border-border',
+        community: 'bg-white rounded-5 border border-border h-8',
         detail: 'bg-primary-main100 rounded-3xl pl-14',
       },
     },
@@ -71,7 +71,7 @@ const SearchBar = ({ variant, className, ...props }: SearchInputProps) => {
       {isDetail && inputValue && (
         <button
           type='button'
-          className='absolute -translate-y-1/2 right-3 top-1/2 text-primary'
+          className='absolute right-3 top-1/2 -translate-y-1/2 text-primary'
           onClick={() => setInputValue('')}
         >
           <Icon name='CLOSE' size={13} />

--- a/src/components/page/community/CommentEditForm.tsx
+++ b/src/components/page/community/CommentEditForm.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useState, useRef, useEffect } from 'react';
 import { Button } from '@/components/common/button/Button';
 import Textarea from '@/components/common/Textarea';

--- a/src/components/page/community/CommentPostForm.tsx
+++ b/src/components/page/community/CommentPostForm.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useState, useRef } from 'react';
 import { Button } from '@/components/common/button/Button';
 import Textarea from '@/components/common/Textarea';

--- a/src/components/page/community/PostListItem.tsx
+++ b/src/components/page/community/PostListItem.tsx
@@ -26,14 +26,14 @@ const PostListItem = ({
     <div className='flex items-center border-b border-divider bg-bg transition last:border-b-0 hover:brightness-[0.98]'>
       {checkbox && <input type='checkbox' className='cursor-pointer' />}
       <Link
-        href={`/post/${postId}`}
+        href={`/community/${postId}`}
         className='flex w-full flex-col gap-y-[10px] px-[20px] py-[20px]'
       >
-        <p className='truncate font-semibold'>{title}</p>
+        <p className='font-semibold truncate'>{title}</p>
         <p className='overflow-hidden text-ellipsis text-nowrap text-body2 text-text-sub'>
           {content}
         </p>
-        <div className='flex w-full items-center justify-between pt-2 text-body2'>
+        <div className='flex items-center justify-between w-full pt-2 text-body2'>
           <p className='flex items-center gap-x-[6px]'>
             <Avatar
               name={String(author.profileCode)}

--- a/src/components/page/community/PostListToolbar.tsx
+++ b/src/components/page/community/PostListToolbar.tsx
@@ -23,7 +23,7 @@ const PostListToolbar = ({ postCount }: PostListToolbarProps) => {
             fontSize='sm'
             menuItems={[
               { label: '최신순', onClick: () => {} },
-              { label: '댓글많은순', onClick: () => {} },
+              { label: '댓글 많은 순', onClick: () => {} },
               { label: '좋아요순', onClick: () => {} },
               { label: '과거순', onClick: () => {} },
             ]}


### PR DESCRIPTION
<br/>

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] develop 브랜치에서 최신 데이터를 가져오기 위한 PR

<br/><br/>

## PR 상세

### 주요 변경 사항
- **전체 게시글 페이지 UI 구성**
   - 추가한 컴포넌트
      - 페이지 제목
      - 검색 Input 컴포넌트
      - 드롭다운 컴포넌트
      - 게시글 개수 표시 컴포넌트
      - 게시글 아이템 리스트 컴포넌트
   - 임시 데이터를 활용하여 전체 UI 배치 확인

- **커뮤니티 게시글 상세 페이지 생성**
   - `app/(main-layout)/community/[postId]/page.tsx` 파일을 통해 상세 페이지 라우팅 처리
   - `PostListItem` 컴포넌트 내 링크 경로를 동적 라우팅에 맞게 수정

- **클라이언트 컴포넌트로 인식되지 않던 컴포넌트에 'use client' 지시자 추가**
   - 수정 대상 컴포넌트
     - `CommentEditForm`
     - `CommentPostForm`

- **드롭다운 컴포넌트 텍스트 줄바꿈 및 커서 깜빡임 문제 수정**
   - 문제점
     - 텍스트가 길 경우 줄바꿈 되어 레이아웃이 깨지는 현상
     - 드롭다운 버튼 텍스트에 포커스 시 커서가 깜빡이는 시각적 이슈 발생
      <img width="276" height="113" alt="image (2)" src="https://github.com/user-attachments/assets/f3453e67-cb8c-4ef6-bd5a-5a5316226c86" />

   - 해결 방법
     - 버튼 width를 `w-24`에서 `w-26`으로 조정하여 텍스트 줄바꿈 방지
     - 텍스트 영역에 `select-none`을 적용하여 커서 깜빡임 제거
     <img width="315" height="425" alt="image (1)" src="https://github.com/user-attachments/assets/51bfa044-5c46-4bb5-9941-d54f2c635558" />

<br/>

### 스크린샷
- 전체 게시글 페이지
  <img width="2868" height="1423" alt="image" src="https://github.com/user-attachments/assets/21fbdc33-ef1e-4241-8e54-d73ea3b9c0fd" />

<br/>

### 테스트
- 로컬에서 정상 동작 확인했습니다.

<br/>

### 참고사항
- 커뮤니티 페이지의 전체 게시글 페이지 UI 구현만 진행했습니다.
- 기타 게시글 상세 페이지나 기능은 이후 다른 브랜치로 진행할 예정입니다.

<br/><br/>

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 의도한 대로 동작하는지 테스트를 했습니다.
- [x] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.
